### PR TITLE
feat(Moderator/Admin) Manage User 

### DIFF
--- a/qq
+++ b/qq
@@ -1,0 +1,13 @@
+  auth-temp[m
+  backup-fg[m
+  backup-ve[m
+  feat/auth-basic[m
+  feat/auth-logout-confirm-forgot[m
+  feat/forgot-password[m
+  feat/logout-verify-email[m
+* [32mfeat/manage-user[m
+  feat/view-and-edit-profile[m
+  init-model[m
+  init-project[m
+  master[m
+  refactor-interceptor-transform-data[m

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { CoreModule } from './core/core.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { UserModule } from './user/user.module';
 import { AuthGuard } from './common/guards/auth.guard';
+import { RoleGuard } from './common/guards/role.guard';
 
 @Module({
   imports: [
@@ -62,6 +63,10 @@ import { AuthGuard } from './common/guards/auth.guard';
     {
       provide: 'APP_GUARD',
       useClass: AuthGuard,
+    },
+    {
+      provide: 'APP_GUARD',
+      useClass: RoleGuard,
     },
   ],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,12 +5,14 @@ import { ForgotPasswordTokenPayload } from './interfaces/forgot-password-token-p
 import { UserValidate } from './interfaces/user-validate';
 import { VerifyEmailTokenPayload } from './interfaces/verify-email-token-payload';
 import { I18nService } from 'nestjs-i18n';
+import { CustomLogger } from 'src/common/logger/custom-logger.service';
 
 @Injectable()
 export class AuthService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly i18nService: I18nService,
+    private readonly loggerService: CustomLogger,
   ) {}
   async generateAccessToken(
     payload: AccessTokenPayload,
@@ -25,11 +27,9 @@ export class AuthService {
     try {
       return await this.jwtService.verifyAsync<UserValidate>(token, options);
     } catch (error) {
-      console.error(error);
+      this.loggerService.error('Verify token failed', JSON.stringify(error));
       throw new UnauthorizedException(
-        this.i18nService.translate(
-          'common.request.errors.token_invalid_expired',
-        ),
+        this.i18nService.translate('common.request.errors.tokenInvalidExpired'),
       );
     }
   }

--- a/src/common/decorators/role.decorator.ts
+++ b/src/common/decorators/role.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../enums/role.enum';
+export const HAS_ROLE_KEY = 'has_role_key';
+export const HasRole = (...roles: Role[]) => SetMetadata(HAS_ROLE_KEY, roles);

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -31,6 +31,10 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     let detail: object | string | undefined;
     let code = UNKNOWN_ERROR_CODE;
     let message = UNKNOWN_MESSAGE;
+    this.loggerService.error(
+      'Error catch by filter',
+      JSON.stringify(exception),
+    );
     if (exception instanceof MailException) {
       status = this.mapMailStatus(exception.code);
       code = exception.code;
@@ -68,13 +72,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       case MailErrorCode.TIME_OUT:
         return 'timeout';
       case MailErrorCode.TEMPLATE_ERROR:
-        return 'template_error';
+        return 'templateError';
       case MailErrorCode.INVALID_RECIPIENT:
-        return 'invalid_recipient';
+        return 'invalidRecipient';
       case MailErrorCode.INVALID_PAYLOAD:
-        return 'invalid_payload';
+        return 'invaliPayload';
       default:
-        return 'server_error';
+        return 'serverError';
     }
   }
   private mapMailStatus(code: MailErrorCode): number {

--- a/src/common/guards/auth.guard.ts
+++ b/src/common/guards/auth.guard.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
+import { I18nService } from 'nestjs-i18n';
 import { AuthService } from 'src/auth/auth.service';
 import { isPublicRoute } from '../helpers/auth.helper';
 import { extractTokenFromHeader } from '../utils/jwt.util';
@@ -15,12 +16,19 @@ export class AuthGuard implements CanActivate {
   constructor(
     private readonly authService: AuthService,
     private readonly reflector: Reflector,
+    private readonly i18nService: I18nService,
   ) {}
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    if (isPublicRoute(this.reflector, context)) return true;
     const request = context.switchToHttp().getRequest<Request>();
+    if (isPublicRoute(this.reflector, context)) {
+      request['public_route'] = true;
+      return true;
+    }
     const token = extractTokenFromHeader(request);
-    if (!token) throw new UnauthorizedException();
+    if (!token)
+      throw new UnauthorizedException(
+        this.i18nService.translate('common.token.missing'),
+      );
     const user = await this.authService.verifyToken(token);
     request['user'] = user;
     return true;

--- a/src/common/guards/role.guard.spec.ts
+++ b/src/common/guards/role.guard.spec.ts
@@ -1,0 +1,7 @@
+import { RoleGuard } from './role.guard';
+
+describe('RoleGuard', () => {
+  it('should be defined', () => {
+    expect(new RoleGuard()).toBeDefined();
+  });
+});

--- a/src/common/guards/role.guard.ts
+++ b/src/common/guards/role.guard.ts
@@ -1,0 +1,49 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { Observable } from 'rxjs';
+import { AccessTokenPayload } from 'src/auth/interfaces/access-token-payload';
+import { HAS_ROLE_KEY } from '../decorators/role.decorator';
+import { Role } from '../enums/role.enum';
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly i18nService: I18nService,
+  ) {}
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const isPublicRoute = request['public_route'] as boolean;
+    if (isPublicRoute) return true;
+    const rolesRequired = this.reflector.getAllAndOverride<Role[]>(
+      HAS_ROLE_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+    if (!rolesRequired) return true;
+    const user = request['user'] as AccessTokenPayload;
+    if (!user)
+      throw new UnauthorizedException(
+        this.i18nService.translate('common.auth.unauthorized'),
+      );
+    if (!this.hasRole(rolesRequired, user.role))
+      throw new ForbiddenException(
+        this.i18nService.translate('common.auth.forbidden'),
+      );
+    return true;
+  }
+  private hasRole(rolesRequired: Role[], userRole: string): boolean {
+    return rolesRequired.some(
+      (roleRequired) => roleRequired.toLowerCase() === userRole.toLowerCase(),
+    );
+  }
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,6 +1,7 @@
 {
     "auth": {
     "unauthorized": "You are not authorized. Please login.",
+    "forbidden":"You do not have permission to access this resource.",
     "login": {
       "success": "Login successfully",
       "failed": "Invalid user credentials",
@@ -31,22 +32,28 @@
   },
    "request": {
     "errors": {
-      "token_invalid_expired": "Token is invalid or expired",
-      "token_invalid": "The token is invalid.",
-      "token_not_found": "Token not found.",
-      "token_expired": "The token has expired.",
-      "email_not_found": "email not found.",
-      "missing_parameters": "Some required parameters are missing."
+      "tokenInvalidExpired": "Token is invalid or expired",
+      "tokenInvalid": "The token is invalid.",
+      "tokenNotFound": "Token not found.",
+      "tokenExpired": "The token has expired.",
+      "emailNotFound": "email not found.",
+      "missingParameters": "Some required parameters are missing."
     }
   },
   "user": {
     "notFound": "User not found",
     "alreadyVerified": "Account already verified",
     "notVerified": "Account not verified",
+    "roleNotFound":"Role not found",
     "status": {
       "pending": "Pending",
       "active": "Active",
       "deactivated": "Deactivated"
+    },
+    "action": {
+    "statusMissing": "Please provide a user status.",
+    "roleMissing":"Please provide a role change.",    
+    "statusUpdated": "User status updated successfully."
     }
   },
   "profile":{
@@ -56,6 +63,7 @@
     }
   },
   "token": {
+    "missing":"Authorization token is required",
     "invalid": "Invalid token",
     "expired": "Token has expired",
     "blacklisted": "Token is revoked"
@@ -66,27 +74,27 @@
   },
   "mail": {
     "send": {
-      "type_not_null":"type email must not be null",
-      "invalid_type":"invalid type email",
+      "typeNotNull":"type email must not be null",
+      "invalidType":"invalid type email",
       "success": "Email has been sent successfully.",
       "failed": "Failed to send the email.",
-      "invalid_recipient": "Invalid recipient email address.",
-      "server_error": "Mail server error. Please try again later.",
+      "invalidRecipient": "Invalid recipient email address.",
+      "serverError": "Mail server error. Please try again later.",
       "timeout": "Email sending timed out.",
-      "template_error": "Email template could not be loaded.",
-      "username_not_null": "Recipient username is required.",
-      "token_not_null": "Token is required for sending the email.",
-      "expires_at_not_null": "Expiration date is required for the email.",
-      "invalid_payload": "The provided data for sending the email is invalid."
+      "templateError": "Email template could not be loaded.",
+      "usernameNotNull": "Recipient username is required.",
+      "tokenNotNull": "Token is required for sending the email.",
+      "expiresAtNotNull": "Expiration date is required for the email.",
+      "invalidPayload": "The provided data for sending the email is invalid."
     }
   },
   "validation": {
     "error":"Validation Error",
-    "is_string": "The field {field} must be a string.",
-    "is_not_empty": "The field {field} cannot be empty.",
-    "is_enum": "The field {field} must be one of the allowed values.",
-    "is_number": "The field {field} must be a number.",
-    "is_boolean": "The field {field} must be a boolean value.",
-    "is_date": "The field {field} must be a valid date."
+    "isString": "The field {field} must be a string.",
+    "isNotEmpty": "The field {field} cannot be empty.",
+    "isEnum": "The field {field} must be one of the allowed values.",
+    "isNumber": "The field {field} must be a number.",
+    "isBoolean": "The field {field} must be a boolean value.",
+    "isDate": "The field {field} must be a valid date."
   }
 }

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -1,6 +1,7 @@
 {
   "auth": {
     "unauthorized": "Bạn không được phép truy cập. Vui lòng đăng nhập.",
+    "forbidden":"Bạn không có quyền truy cập tài nguyên này.",
     "login": {
       "success": "Đăng nhập thành công",
       "failed": "Thông tin đăng nhập không hợp lệ",
@@ -31,23 +32,29 @@
   },
     "request": {
     "errors": {
-      "token_invalid_expired": "Token không hợp lệ hoặc đã hết hạn",
-      "token_invalid": "Token không hợp lệ.",
-      "token_not_found": "Không tìm thấy token.",
-      "token_expired": "Token đã hết hạn.",
-      "email_not_found": "Không tìm thấy địa chỉ email.",
-      "missing_parameters": "Thiếu một số tham số bắt buộc."
+      "tokenInvalidExpired": "Token không hợp lệ hoặc đã hết hạn",
+      "tokenInvalid": "Token không hợp lệ.",
+      "tokenNotFound": "Không tìm thấy token.",
+      "tokenExpired": "Token đã hết hạn.",
+      "emailNotFound": "Không tìm thấy địa chỉ email.",
+      "missingParameters": "Thiếu một số tham số bắt buộc."
     }
   },
   "user": {
     "notFound": "Không tìm thấy người dùng",
     "alreadyVerified": "Tài khoản đã được xác minh",
     "notVerified": "Tài khoản chưa được xác minh",
+    "roleNotFound":"Không tìm thấy vai trò",
     "status": {
-      "pending": "Đang chờ",
+      "pending": "Đang chờ xác thực",
       "active": "Hoạt động",
       "deactivated": "Đã vô hiệu hóa"
-    }
+    },
+     "action": {
+      "statusMissing": "Vui lòng cung cấp trạng thái người dùng.",
+      "roleMissing":"Vui lòng cung cấp vai trò cần thay đổi.",    
+      "statusUpdated": "Cập nhật trạng thái người dùng thành công."
+      }
   },
   "profile":{
     "action":{
@@ -56,6 +63,7 @@
     }
   },
   "token": {
+    "missing":"Yêu cầu cung cấp token xác thực",
     "invalid": "Token không hợp lệ",
     "expired": "Token đã hết hạn",
     "blacklisted": "Token đã bị thu hồi"
@@ -66,28 +74,28 @@
   },
   "mail": {
     "send": {
-      "type_not_null":"Loại email gửi không được để trống",
-      "invalid_type":"Loại email gửi không hợp lệ",
+      "typeNotNull":"Loại email gửi không được để trống",
+      "invalidType":"Loại email gửi không hợp lệ",
       "success": "Gửi email thành công.",
       "failed": "Gửi email thất bại.",
-      "invalid_recipient": "Địa chỉ email người nhận không hợp lệ.",
-      "server_error": "Lỗi máy chủ gửi mail. Vui lòng thử lại sau.",
+      "invalidRecipient": "Địa chỉ email người nhận không hợp lệ.",
+      "serverError": "Lỗi máy chủ gửi mail. Vui lòng thử lại sau.",
       "timeout": "Quá thời gian gửi email.",
-      "template_error": "Không thể tải mẫu email.",
-      "username_not_null": "Tên người dùng không được để trống.",
-      "token_not_null": "Token bắt buộc phải có để gửi email.",
-      "expires_at_not_null": "Thời hạn của email là bắt buộc.",
-      "invalid_payload":"Dữ liệu để gửi email không hợp lệ."
+      "templateError": "Không thể tải mẫu email.",
+      "usernameNotNull": "Tên người dùng không được để trống.",
+      "tokenNotNull": "Token bắt buộc phải có để gửi email.",
+      "expiresAtNotNull": "Thời hạn của email là bắt buộc.",
+      "invalidPayload":"Dữ liệu để gửi email không hợp lệ."
     }
   },
   "validation": {
     "error":"Dữ liệu không hợp lệ",
-    "is_string": "Trường {field} phải là chuỗi.",
-    "is_not_empty": "Trường {field} không được để trống.",
-    "is_enum": "Trường {field} phải là một trong các giá trị hợp lệ.",
-    "is_number": "Trường {field} phải là số.",
-    "is_boolean": "Trường {field} phải là giá trị đúng/sai.",
-    "is_date": "Trường {field} phải là ngày hợp lệ."
+    "isString": "Trường {field} phải là chuỗi.",
+    "isNotEmpty": "Trường {field} không được để trống.",
+    "isEnum": "Trường {field} phải là một trong các giá trị hợp lệ.",
+    "isNumber": "Trường {field} phải là số.",
+    "isBoolean": "Trường {field} phải là giá trị đúng/sai.",
+    "isDate": "Trường {field} phải là ngày hợp lệ."
 }
 
 }

--- a/src/user/dto/requests/profile-update.dto.ts
+++ b/src/user/dto/requests/profile-update.dto.ts
@@ -4,14 +4,14 @@ import { i18nValidationMessage } from 'nestjs-i18n';
 export class ProfileUpdateRequestDto {
   @IsOptional()
   @IsString({
-    message: i18nValidationMessage('common.validation.is_string', {
+    message: i18nValidationMessage('common.validation.isString', {
       constraint: 'name',
     }),
   })
   name?: string;
   @IsOptional()
   @IsString({
-    message: i18nValidationMessage('common.validation.is_string', {
+    message: i18nValidationMessage('common.validation.isString', {
       constraint: 'address',
     }),
   })
@@ -23,7 +23,7 @@ export class ProfileUpdateRequestDto {
   phone?: string;
   @IsOptional()
   @IsString({
-    message: i18nValidationMessage('common.validation.is_string', {
+    message: i18nValidationMessage('common.validation.isString', {
       field: 'bio',
     }),
   })

--- a/src/user/dto/requests/role-update.dto.ts
+++ b/src/user/dto/requests/role-update.dto.ts
@@ -1,0 +1,15 @@
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { i18nValidationMessage } from 'nestjs-i18n';
+import { Role } from 'src/common/enums/role.enum';
+
+export class RoleUpdateRequestDto {
+  @IsEnum(Role, {
+    message: i18nValidationMessage('common.validation.isEnum', {
+      field: 'role',
+    }),
+  })
+  @IsNotEmpty({
+    message: i18nValidationMessage('common.user.action.roleMissing'),
+  })
+  role: string;
+}

--- a/src/user/dto/requests/status-update.dto.ts
+++ b/src/user/dto/requests/status-update.dto.ts
@@ -1,0 +1,18 @@
+import { UserStatus } from '@prisma/client';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsOptional } from 'class-validator';
+import { i18nValidationMessage } from 'nestjs-i18n';
+
+export class StatusUpdateRequestDto {
+  @Transform(({ value }) => {
+    if (value == null) return undefined;
+    return String(value).toUpperCase();
+  })
+  @IsEnum(UserStatus, {
+    message: i18nValidationMessage('common.validation.isEnum', {
+      field: 'status',
+    }),
+  })
+  @IsOptional()
+  status: string;
+}

--- a/src/user/dto/requests/verify-update.dto.ts
+++ b/src/user/dto/requests/verify-update.dto.ts
@@ -1,0 +1,11 @@
+import { Type } from 'class-transformer';
+import { IsBoolean } from 'class-validator';
+import { i18nValidationMessage } from 'nestjs-i18n';
+
+export class VerifyUpdateRequestDto {
+  @IsBoolean({
+    message: i18nValidationMessage('common.validation.isBoolean'),
+  })
+  @Type(() => Boolean)
+  isVerify: boolean;
+}

--- a/src/user/dto/responses/user-summary.dto.ts
+++ b/src/user/dto/responses/user-summary.dto.ts
@@ -2,5 +2,6 @@ export class UserSummaryDto {
   name: string;
   email: string;
   userName: string;
+  status: string;
   isVerified: boolean;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -4,6 +4,8 @@ import {
   Controller,
   Get,
   NotFoundException,
+  Param,
+  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -21,7 +23,11 @@ import { I18nService } from 'nestjs-i18n';
 import { CurrentUser } from 'src/common/decorators/current-user.decorator';
 import { AccessTokenPayload } from 'src/auth/interfaces/access-token-payload';
 import { ProfileUpdateRequestDto } from './dto/requests/profile-update.dto';
-
+import { StatusUpdateRequestDto } from './dto/requests/status-update.dto';
+import { HasRole } from 'src/common/decorators/role.decorator';
+import { Role } from 'src/common/enums/role.enum';
+import { VerifyUpdateRequestDto } from './dto/requests/verify-update.dto';
+import { RoleUpdateRequestDto } from './dto/requests/role-update.dto';
 @Controller('users')
 export class UserController {
   constructor(
@@ -66,6 +72,7 @@ export class UserController {
     return await this.userService.verifyEmail(token);
   }
   @Get('/forgot-password')
+  @IsPublicRoute()
   async forgotPassowrd(@Query('email') email: string) {
     if (!email)
       throw new NotFoundException(
@@ -88,5 +95,29 @@ export class UserController {
     @Body() dto: ProfileUpdateRequestDto,
   ) {
     return await this.userService.updateMyProfile(user, dto);
+  }
+  @HasRole(Role.MODERATOR, Role.ADMIN)
+  @Patch('/:id/status')
+  async changeStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: StatusUpdateRequestDto,
+  ) {
+    return await this.userService.changeStatus(id, dto);
+  }
+  @HasRole(Role.MODERATOR, Role.ADMIN)
+  @Patch('/:id/verify')
+  async changeVerify(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: VerifyUpdateRequestDto,
+  ) {
+    return await this.userService.changeVerify(id, dto);
+  }
+  @HasRole(Role.ADMIN)
+  @Patch('/:id/role')
+  async changeRole(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: RoleUpdateRequestDto,
+  ) {
+    return await this.userService.changeRole(id, dto);
   }
 }


### PR DESCRIPTION
- Triển khai RoleGuard, RoleDecorator (Phục vụ mục đích xác thực quyền của người dùng có quền sử dụng tài nguyên không)
- Triển khai tính năng thay đổi trạng thái (Change status) & Đánh dầu người dùng đã được verified (Change Verify) cho người dùng (MODERATOR/ADMIN)
- Triển khai tính năng thay đổi role (ADMIN)
- Refactor file common (vi/en) về 1 dịnh dạng camelCase
- Hạn chế: Hiện tại nếu giá trị thay đổi, trùng với giá trị hiện tại của người dùng đang chỉ trả về null
- Phát triển: Ở pull request sau sẽ sử dụng Interceptors transform data trước khi gửi về cho người dùng. Như (Nếu data trả về là null thì sẽ xét lại status là 204 (Không trạng thái)) / đăng ký tài khoản thành công, nhưng gửi email thất  bại thì hiện message thông báo rõ ràng cho từng trường hợp, / ... Sử dụng i18n để trả message đa ngôn ngữ.
