### PR TITLE
Refactor interceptor transform data

### DIFF
--- a/refactor
+++ b/refactor
@@ -1,0 +1,13 @@
+  auth-temp[m
+  backup-fg[m
+  backup-ve[m
+  feat/auth-basic[m
+  feat/auth-logout-confirm-forgot[m
+  feat/forgot-password[m
+  feat/logout-verify-email[m
+  feat/manage-user[m
+  feat/view-and-edit-profile[m
+  init-model[m
+  init-project[m
+  master[m
+* [32mrefactor-interceptor-transform-data[m

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { UserModule } from './user/user.module';
 import { AuthGuard } from './common/guards/auth.guard';
 import { RoleGuard } from './common/guards/role.guard';
+import { TransformDataInterceptor } from './common/interceptors/transform-data.interceptor';
 
 @Module({
   imports: [
@@ -67,6 +68,10 @@ import { RoleGuard } from './common/guards/role.guard';
     {
       provide: 'APP_GUARD',
       useClass: RoleGuard,
+    },
+    {
+      provide: 'APP_INTERCEPTOR',
+      useClass: TransformDataInterceptor,
     },
   ],
 })

--- a/src/common/constants/transform-data.constant.ts
+++ b/src/common/constants/transform-data.constant.ts
@@ -1,0 +1,1 @@
+export const MESSAGE_ACTION_PREFIX = 'action';

--- a/src/common/decorators/resource.decorator.ts
+++ b/src/common/decorators/resource.decorator.ts
@@ -1,0 +1,9 @@
+import { applyDecorators, SetMetadata } from '@nestjs/common';
+export const MESSAGE_RESOURCE_KEY = 'message_resource_key';
+export const MESSAGE_RESOURCE_ACTION = 'message_resource_action';
+export const MessageResource = (resource: string, context?: string) => {
+  return applyDecorators(
+    SetMetadata(MESSAGE_RESOURCE_KEY, resource),
+    SetMetadata(MESSAGE_RESOURCE_ACTION, context),
+  );
+};

--- a/src/common/enums/status-key.enum.ts
+++ b/src/common/enums/status-key.enum.ts
@@ -1,0 +1,10 @@
+export enum StatusKey {
+  SUCCESS = 'success',
+  FAILED = 'failed',
+  UNCHANGED = 'unChanged',
+  PENDING = 'pending',
+  SEND_MAIL_FAILED = 'emailSendFailed',
+  INVALID_OR_EXPIRED = 'invalidOrExpired',
+  IS_VERIFIED = 'isVerified',
+  ALREADY_VERIFIED = 'alreadyVerified',
+}

--- a/src/common/helpers/i18n.helper.ts
+++ b/src/common/helpers/i18n.helper.ts
@@ -1,0 +1,16 @@
+import { I18nService } from 'nestjs-i18n';
+import { CustomLogger } from '../logger/custom-logger.service';
+
+export function getTranslatedMessage(
+  i18n: I18nService,
+  key: string,
+  fallback = 'Operation completed',
+  logger?: CustomLogger,
+): string {
+  const translated = i18n.translate<string>(key) as string;
+  if (!translated || translated === key) {
+    logger?.warn?.(`i18n key "${key}" not found. Fallback: "${fallback}"`);
+    return fallback;
+  }
+  return translated;
+}

--- a/src/common/helpers/resource-name.helper.ts
+++ b/src/common/helpers/resource-name.helper.ts
@@ -1,0 +1,8 @@
+import { ExecutionContext } from '@nestjs/common';
+
+export function getResourceName(context: ExecutionContext): string {
+  return context
+    .getClass()
+    .name.replace(/Controller$/, '')
+    .toLowerCase();
+}

--- a/src/common/helpers/response.helper.ts
+++ b/src/common/helpers/response.helper.ts
@@ -1,0 +1,15 @@
+import { HttpStatus } from '@nestjs/common';
+import { StatusKey } from '../enums/status-key.enum';
+
+export function resolveSuccess(
+  statusCode: HttpStatus,
+  statusKey: StatusKey,
+): boolean {
+  if (statusCode < HttpStatus.OK || statusCode >= HttpStatus.AMBIGUOUS) {
+    return false;
+  }
+  if ([StatusKey.FAILED].includes(statusKey)) {
+    return false;
+  }
+  return true;
+}

--- a/src/common/interceptors/transform-data.interceptor.spec.ts
+++ b/src/common/interceptors/transform-data.interceptor.spec.ts
@@ -1,0 +1,7 @@
+import { TransformDataInterceptor } from './transform-data.interceptor';
+
+describe('TransformDataInterceptor', () => {
+  it('should be defined', () => {
+    expect(new TransformDataInterceptor()).toBeDefined();
+  });
+});

--- a/src/common/interceptors/transform-data.interceptor.ts
+++ b/src/common/interceptors/transform-data.interceptor.ts
@@ -1,0 +1,88 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  HttpStatus,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Response } from 'express';
+import { I18nService } from 'nestjs-i18n';
+import { map, Observable } from 'rxjs';
+import { MESSAGE_ACTION_PREFIX } from '../constants/transform-data.constant';
+import {
+  MESSAGE_RESOURCE_ACTION,
+  MESSAGE_RESOURCE_KEY,
+} from '../decorators/resource.decorator';
+import { StatusKey } from '../enums/status-key.enum';
+import { getResourceName } from '../helpers/resource-name.helper';
+import { resolveSuccess } from '../helpers/response.helper';
+import { CustomLogger } from '../logger/custom-logger.service';
+import {
+  isBaseResponse,
+  normalizePayload,
+  parseStatusKey,
+} from '../utils/data.util';
+import { getTranslatedMessage } from '../helpers/i18n.helper';
+
+@Injectable()
+export class TransformDataInterceptor implements NestInterceptor {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly i18nService: I18nService,
+    private readonly loggerService: CustomLogger,
+  ) {}
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const ctx = context.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const resourceName =
+      this.reflector.getAllAndOverride<string>(MESSAGE_RESOURCE_KEY, [
+        context.getHandler(),
+      ]) || getResourceName(context).toLowerCase();
+    const resourceAction =
+      this.reflector.getAllAndOverride<string>(MESSAGE_RESOURCE_ACTION, [
+        context.getHandler(),
+      ]) || context.getHandler().name;
+    return next.handle().pipe(
+      map((data) => {
+        const statusCode = response.statusCode;
+        const isResponse = isBaseResponse(data);
+        const statusKey = parseStatusKey(
+          isResponse ? data.statusKey : undefined,
+          statusCode,
+        );
+        if (statusKey == StatusKey.UNCHANGED) {
+          response.status(HttpStatus.NO_CONTENT);
+        }
+        let messageActionPrefix = MESSAGE_ACTION_PREFIX;
+        if (!messageActionPrefix) {
+          messageActionPrefix = 'action';
+          this.loggerService.warn(
+            "MESSAGE_ACTION_PREFIX is undefined - fallback to 'action'",
+          );
+        }
+        const messageKey = `common.${resourceName}.${messageActionPrefix}.${resourceAction}.${statusKey}`;
+        this.loggerService.debug(
+          this.i18nService.translate(messageKey) instanceof Promise
+            ? 'Promise'
+            : 'Non-Promise',
+        );
+        const message = getTranslatedMessage(
+          this.i18nService,
+          messageKey,
+          'Operation completed',
+          this.loggerService,
+        );
+        const payload = isResponse
+          ? normalizePayload(data.data)
+          : normalizePayload(data);
+        return {
+          success: resolveSuccess(statusCode, statusKey),
+          statusCode: statusCode,
+          message,
+          payload,
+        };
+      }),
+    );
+  }
+}

--- a/src/common/interfaces/base-response.ts
+++ b/src/common/interfaces/base-response.ts
@@ -1,0 +1,4 @@
+export interface BaseResponse<T> {
+  statusKey: string;
+  data?: T;
+}

--- a/src/common/utils/data.util.ts
+++ b/src/common/utils/data.util.ts
@@ -1,3 +1,7 @@
+import { HttpStatus } from '@nestjs/common';
+import { StatusKey } from '../enums/status-key.enum';
+import { BaseResponse } from '../interfaces/base-response';
+
 export function omitData<T, K extends keyof T>(obj: T, keyExculeds: K[]) {
   const clone = { ...obj };
   keyExculeds.forEach((key) => delete clone[key]);
@@ -9,4 +13,36 @@ export function removeEmpty<T extends object>(obj: T): Partial<T> {
       ([, value]) => value !== undefined && value !== null,
     ),
   ) as Partial<T>;
+}
+export function buildBaseResponse<T>(
+  key: StatusKey,
+  data?: T,
+): BaseResponse<T> {
+  return {
+    statusKey: key,
+    data: data,
+  };
+}
+export function isBaseResponse(obj: unknown): obj is BaseResponse<unknown> {
+  return obj !== null && typeof obj === 'object' && 'statusKey' in obj;
+}
+export function normalizePayload(
+  data: unknown,
+): null | Record<string, unknown> | unknown[] | string | number | boolean {
+  if (data === undefined || data === null) return null;
+  if (Array.isArray(data)) return data as unknown[];
+  if (typeof data === 'object') return data as Record<string, unknown>;
+  return data as string | number | boolean;
+}
+export function parseStatusKey(
+  statusKey: string | undefined,
+  statusCode: HttpStatus,
+): StatusKey {
+  if (statusKey && Object.values(StatusKey).includes(statusKey as StatusKey)) {
+    return statusKey as StatusKey;
+  }
+  if (statusCode === HttpStatus.NO_CONTENT) return StatusKey.UNCHANGED;
+  if (statusCode >= HttpStatus.OK && statusCode < HttpStatus.AMBIGUOUS)
+    return StatusKey.SUCCESS;
+  return StatusKey.FAILED;
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -3,9 +3,10 @@
     "unauthorized": "You are not authorized. Please login.",
     "forbidden":"You do not have permission to access this resource.",
     "login": {
-      "success": "Login successfully",
-      "failed": "Invalid user credentials",
       "unauthorized": "Unauthorized access",
+      "notVerified": "User is not verified yet.",
+      "deactivated": "User account is deactivated.",
+      "invalidCredentials":"Invalid user credentials.",
       "validation":{
         "userNameNotEmpty":"User must not be empty",
         "passwordNotEmpty":"Password must not be empty",
@@ -13,7 +14,10 @@
       }
     },
     "signup": {
-      "success": "User created successfully",
+      "success": "User created successfully, please check email is verify account",
+      "pending":"The account has been created. Please click on the send mail option to verify your account",
+      "failed": "Failed to create user. Please try again later.",
+      "sendMailFailed":"User created successfully, but the confirmation email could not be sent. Please contact support.",
       "emailExists": "Email already exists",
       "phoneExists": "Phone number already exists",
       "usernameExists": "Username already exists",
@@ -26,8 +30,8 @@
         "invalidFormatPhone":"The phone number is invalid."
       }
     },
-    "logout": {
-      "success": "Logout successfully"
+    "resendEmail":{
+      "invalidOrExpired":"Email is invalid or already verified"
     }
   },
    "request": {
@@ -51,9 +55,62 @@
       "deactivated": "Deactivated"
     },
     "action": {
-    "statusMissing": "Please provide a user status.",
-    "roleMissing":"Please provide a role change.",    
-    "statusUpdated": "User status updated successfully."
+        "statusMissing": "Please provide a user status.",
+        "roleMissing":"Please provide a role change.", 
+        "nonUpdate":"User role i",
+        "roleUpdated": "User role updated successfully.",
+        "signup":{
+          "success": "Your account has been created successfully. Please check your email to verify your account.",
+          "pending": "Your account has been registered. Please click the verification option to resend the confirmation email.",
+          "emailSendFailed": "Your account has been created, but we could not send the verification email. Please try resending the email later."
+        },
+        "login":{
+          "success": "Login successfully",
+          "failed": "Invalid user credentials"
+        },
+        "sendVeirifyEmail":{
+          "success":"Verification email has been sent successfully",
+          "failed":"Failed to send verification email. Please try again later"
+        },
+        "logout": {
+          "success": "Logout successfully",
+          "failed":"Logout failed. Please try again"
+        },
+        "verifyEmail":{
+          "success":"Your email has been successfully verified",
+          "failed":"Email verification failed due to a system error. Please try again later",
+          "invalidOrExpired":"The verification link is invalid or has expired",
+          "alreadyVerified":"Your email has already been verified"
+        },
+         "forgotPassword": {
+            "success": "Password reset instructions have been sent to your email",
+            "failed": "Failed to process password reset request. Please try again later"
+        },
+         "resetPassword": {
+          "success": "Your password has been reset successfully",
+          "invalidOrExpired": "The reset link is invalid or has expired",
+          "failed": "Failed to reset password. Please try again later"
+        },
+         "myProfile": {
+          "success": "Your profile information has been retrieved successfully"
+        },
+        "updateMyProfile":{
+          "success": "Your profile has been updated successfully",
+          "unchanged": "No changes were made to your profile",
+          "failed": "Failed to update your profile. Please try again later"
+        },
+        "changeStatus":{
+          "success": "User status updated successfully.",
+          "unChanged":"The user status remains unchanged."
+        },
+         "changeVerify":{
+          "success": "User verify updated successfully.",
+          "unChanged":"The user veirfy remains unchanged."
+        },
+         "changeRole":{
+          "success": "User role updated successfully.",
+          "unChanged":"The user role remains unchanged."
+        }
     }
   },
   "profile":{
@@ -92,7 +149,7 @@
     "error":"Validation Error",
     "isString": "The field {field} must be a string.",
     "isNotEmpty": "The field {field} cannot be empty.",
-    "isEnum": "The field {field} must be one of the allowed values.",
+    "isEnum": "The field {field} must be one of the allowed values {enum}.",
     "isNumber": "The field {field} must be a number.",
     "isBoolean": "The field {field} must be a boolean value.",
     "isDate": "The field {field} must be a valid date."

--- a/src/locales/vi/common.json
+++ b/src/locales/vi/common.json
@@ -5,7 +5,10 @@
     "login": {
       "success": "Đăng nhập thành công",
       "failed": "Thông tin đăng nhập không hợp lệ",
+      "notVerified": "Tài khoản người dùng chưa được xác thực.",
+      "deactivated": "Tài khoản người dùng đã bị vô hiệu hóa.",
       "unauthorized": "Truy cập không được phép",
+      "invalidCredentials":"Thông tin đăng nhập không hợp lệ.",
       "validation": {
         "userNameNotEmpty": "Tên đăng nhập không được để trống",
         "passwordNotEmpty": "Mật khẩu không được để trống",
@@ -13,7 +16,10 @@
       }
     },
     "signup": {
-      "success": "Tạo tài khoản thành công",
+      "success": "Tạo tài khoản thành công, vui lòng kiểm tra email để xác thực tài khoản",
+      "failed":"Không thể tạo tài khoản. Vui lòng thử lại sau.",
+      "pending":"Tài khoản đã được tạo, vui lòng nhấp vào mục gửi email để xác thực tài khoản",
+      "sendMailFailed":"Tạo tài khoản thành công, nhưng không thể gửi email xác nhận. Vui lòng liên hệ bộ phận hỗ trợ",
       "emailExists": "Email đã tồn tại",
       "phoneExists":"Số điện thoại đã tồn tại",
       "usernameExists": "Tên đăng nhập đã tồn tại",
@@ -28,6 +34,9 @@
     },
     "logout": {
       "success": "Đăng xuất thành công"
+    },
+     "resendEmail":{
+      "invalidOrExpired":"Email không hợp lệ hoặc đã được xác thực"
     }
   },
     "request": {
@@ -51,10 +60,54 @@
       "deactivated": "Đã vô hiệu hóa"
     },
      "action": {
-      "statusMissing": "Vui lòng cung cấp trạng thái người dùng.",
-      "roleMissing":"Vui lòng cung cấp vai trò cần thay đổi.",    
-      "statusUpdated": "Cập nhật trạng thái người dùng thành công."
-      }
+            "statusMissing": "Vui lòng cung cấp trạng thái người dùng.",
+            "roleMissing":"Vui lòng cung cấp vai trò cần thay đổi.",    
+            "signup": {
+              "success": "Tài khoản của bạn đã được tạo thành công. Vui lòng kiểm tra email để xác thực tài khoản.",
+              "pending": "Tài khoản đã được đăng ký. Vui lòng nhấp vào mục xác thực để gửi lại email xác nhận.",
+              "emailSendFailed": "Tài khoản của bạn đã được tạo nhưng gửi email xác minh thất bại. Vui lòng thử gửi lại sau."
+            },
+            "login":{
+              "success": "Đăng nhập thành công",
+              "failed": "Thông tin đăng nhập không hợp lệ"
+            },
+            "sendVerifyEmail": {
+              "success": "Email xác minh đã được gửi thành công",
+              "failed": "Gửi email xác minh thất bại. Vui lòng thử lại sau"
+            },
+            "statusUpdated": "Cập nhật trạng thái người dùng thành công."
+            },
+            "logout": {
+              "success": "Đăng xuất thành công",
+              "failed": "Đăng xuất thất bại. Vui lòng thử lại"
+            },
+            "verifyEmail": {
+              "success": "Email của bạn đã được xác minh thành công",
+              "invalidOrExpired": "Liên kết xác minh không hợp lệ hoặc đã hết hạn",
+              "alreadyVerified": "Email của bạn đã được xác minh trước đó",
+              "failed": "Xác minh email thất bại do lỗi hệ thống. Vui lòng thử lại sau"
+            },
+            "forgotPassword": {
+              "success": "Hướng dẫn đặt lại mật khẩu đã được gửi đến email của bạn",
+              "failed": "Yêu cầu đặt lại mật khẩu thất bại. Vui lòng thử lại sau"
+            },
+            "resetPassword": {
+              "success": "Mật khẩu của bạn đã được đặt lại thành công",
+              "invalidOrExpired": "Liên kết đặt lại mật khẩu không hợp lệ hoặc đã hết hạn",
+              "failed": "Đặt lại mật khẩu thất bại. Vui lòng thử lại sau"
+            },
+             "changeStatus": {
+              "success": "Trạng thái người dùng đã được cập nhật thành công.",
+              "unChanged": "Trạng thái người dùng không có thay đổi."
+            },
+            "changeVerify": {
+              "success": "Trạng thái xác minh của người dùng đã được cập nhật thành công.",
+              "unChanged": "Trạng thái xác minh của người dùng không có thay đổi."
+            },
+            "changeRole": {
+              "success": "Vai trò của người dùng đã được cập nhật thành công.",
+              "unChanged": "Vai trò của người dùng không có thay đổi."
+            }
   },
   "profile":{
     "action":{
@@ -92,7 +145,7 @@
     "error":"Dữ liệu không hợp lệ",
     "isString": "Trường {field} phải là chuỗi.",
     "isNotEmpty": "Trường {field} không được để trống.",
-    "isEnum": "Trường {field} phải là một trong các giá trị hợp lệ.",
+    "isEnum": "Trường {field} phải là một trong các giá trị hợp lệ {enum}.",
     "isNumber": "Trường {field} phải là số.",
     "isBoolean": "Trường {field} phải là giá trị đúng/sai.",
     "isDate": "Trường {field} phải là ngày hợp lệ."

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -70,7 +70,7 @@ export class MailService {
   private getTempalte(type: MailType): string {
     switch (type) {
       case MAIL_TYPE.VERIFY_EMAIL:
-        return 'verify-email';
+        return 'verify-emaizl';
       case MAIL_TYPE.FORGOT_PASWORD:
         return 'forgot-password';
     }

--- a/src/user/dto/requests/role-update.dto.ts
+++ b/src/user/dto/requests/role-update.dto.ts
@@ -6,6 +6,7 @@ export class RoleUpdateRequestDto {
   @IsEnum(Role, {
     message: i18nValidationMessage('common.validation.isEnum', {
       field: 'role',
+      enum: '(user/moderator/admin)',
     }),
   })
   @IsNotEmpty({

--- a/src/user/dto/requests/status-update.dto.ts
+++ b/src/user/dto/requests/status-update.dto.ts
@@ -11,6 +11,7 @@ export class StatusUpdateRequestDto {
   @IsEnum(UserStatus, {
     message: i18nValidationMessage('common.validation.isEnum', {
       field: 'status',
+      enum: '(active/deactived)',
     }),
   })
   @IsOptional()

--- a/src/user/dto/responses/resend-verify-email.dto.ts
+++ b/src/user/dto/responses/resend-verify-email.dto.ts
@@ -2,5 +2,5 @@ import { SendMailStatus } from 'src/user/constant/email.constant';
 
 export class ResendVerifyEmailResponseDto {
   sendMailStatus: SendMailStatus;
-  expiresAt: string;
+  expiresAt: string | null;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -28,6 +28,7 @@ import { HasRole } from 'src/common/decorators/role.decorator';
 import { Role } from 'src/common/enums/role.enum';
 import { VerifyUpdateRequestDto } from './dto/requests/verify-update.dto';
 import { RoleUpdateRequestDto } from './dto/requests/role-update.dto';
+import { MessageResource } from 'src/common/decorators/resource.decorator';
 @Controller('users')
 export class UserController {
   constructor(
@@ -36,6 +37,7 @@ export class UserController {
   ) {}
   @Post('/signup')
   @IsPublicRoute()
+  @MessageResource('user', 'signup')
   async signup(@Body() dto: SignupDto) {
     return await this.userService.signup(dto);
   }
@@ -53,6 +55,7 @@ export class UserController {
       );
     return await this.userService.logout(token);
   }
+  @MessageResource('user', 'sendVerifyEmail')
   @Get('/resend-verify-email')
   @IsPublicRoute()
   async resendVerifyEmail(@Query('email') email: string) {
@@ -73,7 +76,7 @@ export class UserController {
   }
   @Get('/forgot-password')
   @IsPublicRoute()
-  async forgotPassowrd(@Query('email') email: string) {
+  async forgotPassword(@Query('email') email: string) {
     if (!email)
       throw new NotFoundException(
         this.i18nService.translate('common.request.errors.email_not_found'),
@@ -82,7 +85,7 @@ export class UserController {
   }
   @Post('/reset-password')
   @IsPublicRoute()
-  async resetPassowrd(@Body() dto: ResetPasswordDto) {
+  async resetPassword(@Body() dto: ResetPasswordDto) {
     return await this.userService.resetPassword(dto);
   }
   @Get('/profile')
@@ -98,6 +101,7 @@ export class UserController {
   }
   @HasRole(Role.MODERATOR, Role.ADMIN)
   @Patch('/:id/status')
+  @MessageResource('user', 'changeStatus')
   async changeStatus(
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: StatusUpdateRequestDto,


### PR DESCRIPTION
- Tại service hiện tại em chỉ trả Data thô. Em mới refactor thêm các Api đều trả về theo dạng {statuKey,data}. Dựa vào statusKey và resource (controller name) và actionFunction (tên của phương thức thực hiện) và keyStatus em sẽ lấy message cho api đó.
- Trong file en/common và vi/common. Em đang tạo 1 object message. Theo type |resource.action.actionFunction.statusKey|, vd: user.action.verifyEmail.success: 'Your email has been successfully verified'. Thì tự động sẽ lấy được message trả cho client tự động theo 3 key (resource name/action function/statusKey). Service không thực hiện trả message.
- Hiện tại theo xử lý tập trung như này: Mỗi lần phát triển chức năng phải thêm các message vào 2 file common tương ứng cho 2 ngôn ngữ theo type |resource.action.actionFunction.statusKey| để trả message chính xác. Hiện tại em không biết cách này có thực sự ổn không. Do phải khai báo khá nhiều trong file common.